### PR TITLE
updated cmake for Mac OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.2)
+
 project (CMakeHelloWorld)
 
 #version number
@@ -7,7 +8,12 @@ set (CMakeHelloWorld_VERSION_MINOR 0)
 
 # Find the BLAS stuff
 find_package(BLAS REQUIRED)
-message(STATUS "BLAS LIB: ${BLAS_LIBRARIES}")
+find_path(BLAS_INCLUDE_DIRS NAMES cblas.h)
+
+message(STATUS "BLAS Include: ${BLAS_INCLUDE_DIRS}")
+message(STATUS "BLAS Libraries: ${BLAS_LIBRARIES}")
+
+include_directories(${BLAS_INCLUDE_DIRS})
 
 #include the subdirectory containing our libs
 add_subdirectory (Hello)


### PR DESCRIPTION
This worked on Mac OSX 10.13.2 with the following commands:

```bash
$ mkdir build
$ cd build
$ cmake ..
$ make
$ ./CMakeHelloWorld
Hello, world!
11.000 -9.000 5.000 -9.000 21.000 -1.000 5.000 -1.000 3.000
```

It appears that the default system installation of BLAS works fine provided the location of the headers is specified.
